### PR TITLE
fix build.gradle: switch mvn repository to jenkins-ci.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url "http://mvnrepository.com/artifact"
+        url "https://repo.jenkins-ci.org/releases"
     }
 }
 


### PR DESCRIPTION
mvnrepository.com misses lots of pom's we need (probably outdated),
but jenkins-ci.org still hosts them. Therefore switch to there.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>